### PR TITLE
Fix `WILDFLY_CHOWN` default value in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Specifies if reverse DNS lookup is enabled for incoming DICOM and HL7 connection
 #### `WILDFLY_CHOWN`
 
 This environment variable is used to set the ownership to the storage directory (optional, default is 
-`"/opt/wildfly/standalone /storage"`
+`"/opt/wildfly/standalone"`).
+
+If you set a custom `STORAGE_DIR` variable, such as `"/storage/fs1"`, remember to add the parent directory of `STORAGE_DIR`. Multiple directories are separated by spaces, e.g.: `"/opt/wildfly/standalone /storage"`.
 
 #### `WILDFLY_WAIT_FOR`
 


### PR DESCRIPTION
## Problem

I set `STORAGE_DIR` to `/storage/fs1` and run the docker container through the `docker` command, but found that the web service cannot upload DICOM files. Going deep into the container, I found that the owner of `/storage` is not `wildfly`.

Because the current version of [Dockerfile](https://github.com/dcm4che-dockerfiles/dcm4chee-arc-psql/blob/eb994808fdb0c0098b22ec2ef4800163f2192660/Dockerfile) does not set the default value of `WILDFLY_CHOWN`. Therefore, I traced back to the `dcm4che/wildfly:ffmpeg-24.0.1-15.0.2` Dockerfile and saw that it only set `WILDFLY_CHOWN` to `$JBOSS_HOME/standalone` in https://github.com/dcm4che-dockerfiles/wildfly/blob/8a907d1ba460082361e33e052910e0dc62ab0c9b/Dockerfile-ffmpeg#L42. That will cause the `/storage` directory not to be changed to `wildfly`.

## Solution

I think we just fixed the default value of `WILDFLY_CHOWN` in README.md and provided example settings, because `STORAGE_DIR` is a custom variable, and set `/storage` to the default value of `WILDFLY_CHOWN` may not be suitable for everyone.